### PR TITLE
Issue templates: Create a "New Story" template (closes #1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-general.md
+++ b/.github/ISSUE_TEMPLATE/01-general.md
@@ -1,6 +1,7 @@
 ---
+name: General feedback
+about: Use this issue template to quickly share feedback or a new idea about the Principles.
 labels: needs triage
-assignees: 'jwflory'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/02-new-story.md
+++ b/.github/ISSUE_TEMPLATE/02-new-story.md
@@ -1,0 +1,23 @@
+---
+name: Add a new Principle Story
+about: Share your own public story about how the Principles applied to your life.
+title: 'New story: [my story title here!]'
+labels: 'T: new story', 'new change'
+
+---
+
+<!-- Thank you for contributing a Principle Story back upstream! Please use this template to help a maintainer review your contribution. -->
+
+## Meta
+
+<!-- Details about you and your story! -->
+
+* **Your preferred name**:
+* **Your title** (if applicable):
+* **Princple**: <!-- Which Principle(s) is this story about? -->
+* **Who is your story about**:
+* **One-sentence summary of your story**:
+
+## Your story
+
+<!-- Freeform response! Write your story below, exactly as you wish it to appear on the website. By submitting this form, you agree these contributions are shared under a Creative Commons Attribution 4.0 (CC-BY) license. This is the default license of the Principles. -->


### PR DESCRIPTION
This commit moves the repository over to use multiple issue templates
simultaneously. One is more customized for accepting new contributions
as "stories", which are how we describe the practical applications of
the Principles.

I hope this issue template facilitates easier contributions of new
stories. For now, I think this helps enable us to build this work
further.

Closes #1.