### PR TITLE
docs: Add meta doc about how to contribute a story

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,14 @@ To find the Creative Commons-licensed source for these Principles, see the `GitH
 
     advocate-kit/*
 
+.. toctree::
+    :maxdepth: 2
+    :name: meta
+    :caption: Meta topics:
+    :glob:
+
+    meta/*
+
 
 ****************
 High-level recap

--- a/docs/meta/contribute-story.md
+++ b/docs/meta/contribute-story.md
@@ -1,0 +1,41 @@
+# Contribute a story
+
+The Principles of Authentic Participation are guidelines and best practices for participating in open source communities.
+However, it is just a loose framework.
+What gives these Principles a life is the stories we tell about them.
+
+What does this mean?
+Stories are examples of how the Principles of Authentic Participation play out and apply to the real world.
+We encourage people who have stories, retrospectives, and learnings they can share publicly to do so here.
+
+
+## Submit a story
+
+There are two ways to submit a story and get it published here:
+
+1. Open an issue to share your story and a maintainer can commit it on your behalf
+1. Open a pull request to add your story directly to the site
+
+### Open an issue
+
+Fill out the [Principle Story template][1] to share your story with us.
+Using this template makes it easier for a maintainer to review your contribution.
+Please use it!
+
+### Open a pull request
+
+Alternatively, if you are comfortable with git, you can add your story directly to the website through a pull request.
+
+```sh
+git clone https://github.com/sustainers/authentic-participation.git
+cd authentic-participation/docs/advocate-kit/
+# open stories.md in your preferred text editor
+```
+
+Consider using this basic template for adding a new story:
+
+```
+Coming soon!
+```
+
+[1]: https://github.com/sustainers/authentic-participation/issues/new?labels=T%3A+new+story%2C+new+change&template=02-new-story.md&title=New+story%3A+%5Bmy+story+title+here%21%5D


### PR DESCRIPTION
@Erioldoesdesign commented in #9 about wanting to contribute a story.
Originally I wanted to work on contributing guidelines after I wrote my
blog post but decided to expedite this in case any early interest crops
up before I get my blog posts done to wrap up here.

:tada:

![Screenshot of local rendered preview](https://user-images.githubusercontent.com/4721034/83082501-a3da2880-a051-11ea-812c-395a951605f5.png "Screenshot of local rendered preview")